### PR TITLE
Fix pasted pictures not shown, when redmine accessed with different domain/host name

### DIFF
--- a/assets/javascripts/application.js
+++ b/assets/javascripts/application.js
@@ -1289,8 +1289,7 @@ function addInlineAttachmentMarkupCKEditor(file) {
 
             if (pasteImageThis) {
 
-                var base_url = $('a.home').prop('href');
-                var img_text = '<img src="' + base_url + 'attachments/download/' + attachmentFileID + '" />'
+                var img_text = '<img src="/attachments/download/' + attachmentFileID + '" />'
 
                 var dt = new DataTransfer();
                 dt.items.add(img_text, 'text/html');


### PR DESCRIPTION
This fixes an issue that pasted images are not shown when redmine is accessed with different domain/host name. The issue was that they are inserted into the html with an absolute url (incl. hostname) but they should have been inserted with an relative path.